### PR TITLE
Target Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 authors = [{ name = "Jonathan Dekhtiar", email = "jonathan@dekhtiar.com" }]
 readme = "README.md"
 dependencies = []
-requires-python = ">=3.13"
+requires-python = ">=3.9"
 
 [tool.uv.sources]
 pip = { workspace = true }
@@ -50,7 +50,6 @@ exclude = [
 # Same as Django: https://github.com/cookiecutter/cookiecutter-django/issues/4792.
 line-length = 88
 indent-width = 4
-target-version = "py312"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Adjust the Python target to Python 3.9, since our work (variantlib most importantly) must be portable to all non-EOL Python versions. Remove the redundant `tool.ruff.target-version` setting, as Ruff infers it from `requires-python`.