### PR TITLE
Running through the testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ PIP is not aware of any NVIDIA CUDA support and reports it:
 
 Consequently the "default variant build": `null-variant` (a variant containing no property) is being picked up:
 ```bash
-torch-2.7.0-00000000 
-torchaudio-2.7.0-00000000 
+torch-2.7.0-00000000
+torchaudio-2.7.0-00000000
 torchvision-0.22.0-00000000
 ```
 
@@ -221,7 +221,7 @@ $ pip install --dry-run torch torchaudio torchvision
 >>>   Using cached https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (3.9 MB)
 >>> Collecting torchvision
 >>>   Using cached https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (8.7 MB)
->>> 
+>>>
 >>> ...
 >>>
 >>> Would install

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ We did not built any variant-artifact for MacOS or ARM CPUs.
 # 1. Create a virtualenv
 # WARNING: Installing Wheel-Variant PEP overwrites PIP.
 # Do not install this in your main python environment.
-$ virtualenv .venv
+$ python3 -m venv .venv
 $ source .venv/bin/activate
+$ cd .venv
 
 # 2. Set the index to the WheelNext Static Wheel Server: MockHouse & Backup to PyPI
 $ pip config set --site global.index-url https://variants-index.wheelnext.dev/
@@ -35,14 +36,14 @@ $ pip install --dry-run torch torchaudio torchvision
 >>> ...
 >>> Would install
         ...
-        torch-2.7.0 
-        torchaudio-2.7.0 
+        torch-2.7.0
+        torchaudio-2.7.0
         torchvision-0.22.0
 ```
 
 ### What happened ?
 
-As you can expect - PIP picked up the default Torch build (same as published on PyPI: CPU + NVIDIA CUDA 12.6). 
+As you can expect - PIP picked up the default Torch build (same as published on PyPI: CPU + NVIDIA CUDA 12.6).
 Built as a normal Python Wheel (aka. non variant)
 
 ## B. Let's install a variant-enabled Python package manager
@@ -99,13 +100,13 @@ $ pip install --dry-run torch torchaudio torchvision
 >>>   Downloading https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (1.8 MB)
 >>> Collecting torchvision
 >>>   Downloading https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (2.0 MB)
->>> 
+>>>
 >>> ...
 >>>
 >>> Would install
         ...
-        torch-2.7.0-00000000 
-        torchaudio-2.7.0-00000000 
+        torch-2.7.0-00000000
+        torchaudio-2.7.0-00000000
         torchvision-0.22.0-00000000
 ```
 
@@ -120,8 +121,8 @@ PIP is not aware of any NVIDIA CUDA support and reports it:
 
 Consequently the "default variant build": `null-variant` (a variant containing no property) is being picked up:
 ```
-torch-2.7.0-00000000 
-torchaudio-2.7.0-00000000 
+torch-2.7.0-00000000
+torchaudio-2.7.0-00000000
 torchvision-0.22.0-00000000
 ```
 
@@ -134,7 +135,7 @@ In the case of PyTorch, the `Null-Variant` is a *CPU-only* PyTorch build.
 - The behavior can be mocked using the environment variable: `NV_PROVIDER_FORCE_DRIVER_VERSION==major.minor`
 
 ```bash
-# This can be used to "pretend" the system has a specific driver. 
+# This can be used to "pretend" the system has a specific driver.
 # However it won't make the wheel functional without the proper environment - can be used to test installation though
 export NV_PROVIDER_FORCE_DRIVER_VERSION="11.8"
 export NV_PROVIDER_FORCE_DRIVER_VERSION="12.6"
@@ -178,7 +179,7 @@ $ nvidia-smi | head -n 4
 >>> |-----------------------------------------+------------------------+----------------------+
 
 # VariantLib can be used to query the compatibility of the platform for each installed plugin
-# In this case - this computer has CUDA 12.8 and therefore this platform has the following 
+# In this case - this computer has CUDA 12.8 and therefore this platform has the following
 # compatibility of variant properties.
 # NOTE: properties are given following a default ordering provided by the provider plugin
 #       within one single namespace. This ordering should not be assumed final or absolute.
@@ -206,13 +207,13 @@ $ pip install --dry-run torch torchaudio torchvision
 >>>   Downloading https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (1.8 MB)
 >>> Collecting torchvision
 >>>   Downloading https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (2.0 MB)
->>> 
+>>>
 >>> ...
 >>>
 >>> Would install
         ...
-        torch-2.7.0-00000000 
-        torchaudio-2.7.0-00000000 
+        torch-2.7.0-00000000
+        torchaudio-2.7.0-00000000
         torchvision-0.22.0-00000000
 ```
 
@@ -227,8 +228,8 @@ PIP is not aware of any NVIDIA CUDA support and reports it:
 
 Consequently the "default variant build": `null-variant` (a variant containing no property) is being picked up:
 ```
-torch-2.7.0-00000000 
-torchaudio-2.7.0-00000000 
+torch-2.7.0-00000000
+torchaudio-2.7.0-00000000
 torchvision-0.22.0-00000000
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,18 @@ We did not built any variant-artifact for MacOS or ARM CPUs.
 
 ## A. Let's validate that an "old installer" is non-affected by any of these changes
 
-### 1. Create a virtualenv to protect your environment
+### 1. Create a virtualenv to isolate your environment
 
 ```bash
 # 1. Create a virtualenv
 # WARNING: Installing Wheel-Variant PEP overwrites PIP.
 # Do not install this in your main python environment.
-$ python3 -m venv .venv
-$ source .venv/bin/activate
-$ cd .venv
+$ python3 -m venv .vstd
+$ source .vstd/bin/activate
 
 # 2. Set the index to the WheelNext Static Wheel Server: MockHouse & Backup to PyPI
 $ pip config set --site global.index-url https://variants-index.wheelnext.dev/
->>> Writing to /path/to/venv/pip.conf
+Writing to /path/to/venv/pip.conf
 ```
 
 ### 2. Test Install a Variant-Enabled package with "normal `pip`"
@@ -31,11 +30,11 @@ By doing this - It **should** install the normal package (aka. non variant), pro
 ```bash
 $ pip install --dry-run torch torchaudio torchvision
 
->>> Looking in indexes: https://variants-index.wheelnext.dev/
->>> Collecting torch
->>>   Downloading https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64.whl (865.8 MB)  # Notice no variant-hash
->>> ...
->>> Would install
+Looking in indexes: https://variants-index.wheelnext.dev/
+Collecting torch
+  Downloading https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64.whl (865.8 MB)  # Notice no variant-hash
+...
+Would install
         ...
         torch-2.7.0
         torchaudio-2.7.0
@@ -49,18 +48,18 @@ Built as a normal Python Wheel (aka. non variant)
 
 ## B. Let's install a variant-enabled Python package manager
 
-### 1. Create a virtualenv to protect your environment
+### 1. Create a virtualenv to isolate your environment
 
 ```bash
 # 1. Create a virtualenv
 # WARNING: Installing Wheel-Variant PEP overwrites PIP.
 # Do not install this in your main python environment.
-$ virtualenv .venv
-$ source .venv/bin/activate
+$ python3 -m venv .vvar
+$ source .vvar/bin/activate
 
 # 2. Set the index to the WheelNext Static Wheel Server: MockHouse & Backup to PyPI
 $ pip config set --site global.index-url https://variants-index.wheelnext.dev/
->>> Writing to /path/to/venv/pip.conf
+Writing to /path/to/venv/pip.conf
 ```
 
 ### 2. Let's install variant-enabled PIP
@@ -72,14 +71,14 @@ $ pip config set --site global.index-url https://variants-index.wheelnext.dev/
 # - pip
 # - variantlib (a new package)
 $ pip install pep-xxx-wheel-variants
->>> Successfully installed pep-xxx-wheel-variants-1.0.0 pip-25.1.dev0+pep.xxx.wheel.variants variantlib-0.0.1.dev1  # and some extra stuff
+Successfully installed pep-xxx-wheel-variants-1.0.0 pip-25.1.dev0+pep.xxx.wheel.variants variantlib-0.0.1.dev1  # and some extra stuff
 
 # Let's verify everything is good:
 $ pip --version
->>> pip 25.1.dev0+pep-xxx-wheel-variants from ...  # <=============== Check you can see `+pep-xxx-wheel-variants`
+pip 25.1.dev0+pep-xxx-wheel-variants from ...  # <=============== Check you can see `+pep-xxx-wheel-variants`
 
 $ variantlib --version
->>> variantlib version: 0.0.1.dev1
+variantlib version: 0.0.1
 ```
 
 ### 3. Test Wheel Variant functionality
@@ -89,23 +88,21 @@ $ variantlib --version
 ```bash
 $ pip install --dry-run torch torchaudio torchvision
 
->>> Looking in indexes: https://variants-index.wheelnext.dev/
->>>   Discovering Wheel Variant plugins...
->>>   Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
->>>   Variant `ba4b552f` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.8]` are not supported or have been explicitly rejected.
->>>   Variant `bee95d34` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.6]` are not supported or have been explicitly rejected.
->>>   Total Number of Compatible Variants: 1
->>>   Total Number of Tags Generated: 2,136
->>> Collecting torch
->>>   Downloading https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (175.4 MB)
->>> Collecting torchaudio
->>>   Downloading https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (1.8 MB)
->>> Collecting torchvision
->>>   Downloading https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (2.0 MB)
->>>
->>> ...
->>>
->>> Would install
+Looking in indexes: https://variants-index.wheelnext.dev/
+  Discovering Wheel Variant plugins...
+  Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
+  Variant `ba4b552f` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.8]` are not supported or have been explicitly rejected.
+  Variant `bee95d34` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.6]` are not supported or have been explicitly rejected.
+  Total Number of Compatible Variants: 1
+  Total Number of Tags Generated: 2,136
+Collecting torch
+  Downloading https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (175.4 MB)
+Collecting torchaudio
+  Downloading https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (1.8 MB)
+Collecting torchvision
+  Downloading https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-00000000.whl (2.0 MB)
+...
+Would install
         ...
         torch-2.7.0-00000000
         torchaudio-2.7.0-00000000
@@ -116,9 +113,9 @@ $ pip install --dry-run torch torchaudio torchvision
 
 PIP is not aware of any NVIDIA CUDA support and reports it:
 ```bash
->>>   Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
->>>   Variant `ba4b552f` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.8]` are not supported or have been explicitly rejected.
->>>   Variant `bee95d34` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.6]` are not supported or have been explicitly rejected.
+  Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
+  Variant `ba4b552f` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.8]` are not supported or have been explicitly rejected.
+  Variant `bee95d34` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12.6]` are not supported or have been explicitly rejected.
 ```
 
 Consequently the "default variant build": `null-variant` (a variant containing no property) is being picked up:
@@ -154,7 +151,7 @@ Let's install the NVIDIA Variant Provider Plugin:
 
 ```bash
 $ pip install nvidia-variant-provider
->>> Successfully installed nvidia-variant-provider-1.0.0
+Successfully installed nvidia-variant-provider-1.0.0
 ```
 
 Let's test the install:
@@ -162,43 +159,44 @@ Let's test the install:
 ```bash
 # Provides a list of variant provider plugins installed on the machine.
 $ variantlib plugins list
->>> variantlib.loader - INFO - Discovering Wheel Variant plugins...
->>> variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
->>> nvidia
+variantlib.loader - INFO - Discovering Wheel Variant plugins...
+variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
+nvidia
 
 # All the "known properties" by the variant provider plugins. They don't need to be compatible on this machine.
 $ variantlib plugins get-all-configs
->>> variantlib.loader - INFO - Discovering Wheel Variant plugins...
->>> variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
->>> nvidia :: driver :: 11.0
->>> nvidia :: driver :: 11.1
->>> ...
->>> nvidia :: driver :: 11.8
->>> nvidia :: driver :: 12.0
->>> nvidia :: driver :: 12.1
->>> ...
->>> nvidia :: driver :: 12.8
->>> nvidia :: driver :: 11
->>> nvidia :: driver :: 12
+variantlib.loader - INFO - Discovering Wheel Variant plugins...
+variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
+nvidia :: driver :: 11.0
+nvidia :: driver :: 11.1
+...
+nvidia :: driver :: 11.8
+nvidia :: driver :: 12.0
+nvidia :: driver :: 12.1
+...
+nvidia :: driver :: 12.8
+nvidia :: driver :: 11
+nvidia :: driver :: 12
 
 $ nvidia-smi | head -n 4
 
->>> +-----------------------------------------------------------------------------------------+
->>> | NVIDIA-SMI 570.133.20             Driver Version: 570.133.20     CUDA Version: 12.8     |
->>> |-----------------------------------------+------------------------+----------------------+
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.133.20             Driver Version: 570.133.20     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
 
 # VariantLib can be used to query the compatibility of the platform for each installed plugin
 # In this case - this computer has CUDA 12.8 and therefore this platform has the following
 # compatibility of variant properties.
 # NOTE: properties are given following a default ordering provided by the provider plugin
 #       within one single namespace. This ordering should not be assumed final or absolute.
+
 $ variantlib plugins get-supported-configs
->>> variantlib.loader - INFO - Discovering Wheel Variant plugins...
->>> variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
->>> nvidia :: driver :: 12.8
->>> ...
->>> nvidia :: driver :: 12.0
->>> nvidia :: driver :: 12
+variantlib.loader - INFO - Discovering Wheel Variant plugins...
+variantlib.loader - INFO - Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
+nvidia :: driver :: 12.8
+...
+nvidia :: driver :: 12.0
+nvidia :: driver :: 12
 ```
 
 Alright now let's try to re-run the command to install `torch torchaudio torchvision`. We should get:
@@ -208,23 +206,21 @@ Alright now let's try to re-run the command to install `torch torchaudio torchvi
 ```bash
 $ pip install --dry-run torch torchaudio torchvision
 
->>> Looking in indexes: https://variants-index.wheelnext.dev/
->>>   Discovering Wheel Variant plugins...
->>>   Loading plugin from entry point: x86_64; provided by package variant_x86_64 0
->>>   Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
->>>   Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
->>>   Total Number of Compatible Variants: 3
->>>   Total Number of Tags Generated: 4,272
->>> Collecting torch
->>>   Using cached https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (1096.4 MB)
->>> Collecting torchaudio
->>>   Using cached https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (3.9 MB)
->>> Collecting torchvision
->>>   Using cached https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (8.7 MB)
->>>
->>> ...
->>>
->>> Would install
+Looking in indexes: https://variants-index.wheelnext.dev/
+  Discovering Wheel Variant plugins...
+  Loading plugin from entry point: x86_64; provided by package variant_x86_64 0
+  Loading plugin from entry point: nvidia_variant_provider; provided by package nvidia-variant-provider 1.0.0
+  Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected.
+  Total Number of Compatible Variants: 3
+  Total Number of Tags Generated: 4,272
+Collecting torch
+  Using cached https://variants-index.wheelnext.dev/torch/torch-2.7.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (1096.4 MB)
+Collecting torchaudio
+  Using cached https://variants-index.wheelnext.dev/torchaudio/torchaudio-2.7.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (3.9 MB)
+Collecting torchvision
+  Using cached https://variants-index.wheelnext.dev/torchvision/torchvision-0.22.0-cp312-cp312-manylinux_2_28_x86_64-ba4b552f.whl (8.7 MB)
+...
+Would install
         ...
         torch-2.7.0-ba4b552f
         torchaudio-2.7.0-ba4b552f
@@ -238,7 +234,7 @@ which explains why the NVIDIA CUDA 11.8 build of PyTorch was rejected.
 Notice that the NVIDIA CUDA 12.6 build was not rejected - just less favored compared to NVIDIA CUDA 12.8 and therefore not installed.
 
 ```bash
->>>   Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected
+  Variant `652626b1` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11.8]` are not supported or have been explicitly rejected
 ```
 
 The installed variant corresponds:


### PR DESCRIPTION
* I like `python3 -m venv` instead of `virtualenv` since the former comes out of the box with Python
* Looks like you have to be in the `.venv` directory for anything to work, otherwise:

```
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
```