### PR TITLE
docs: Update to change pip --> python3 -m pip

### DIFF
--- a/docs/tutorials/PyTorch.md
+++ b/docs/tutorials/PyTorch.md
@@ -26,7 +26,7 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate
 
 # 2. Set the index to the WheelNext Static Wheel Server: MockHouse & Backup to PyPI
-$ pip config set --site global.index-url https://variants-index.wheelnext.dev/
+$ python3 -m pip config set --site global.index-url https://variants-index.wheelnext.dev/
 Writing to /path/to/venv/pip.conf
 ```
 
@@ -35,7 +35,7 @@ Writing to /path/to/venv/pip.conf
 By doing this - It **should** install the normal package (aka. non variant), proving the backward compatibility of the design.
 
 ```bash
-$ pip install --dry-run torch
+$ python3 -m pip install --dry-run torch
 
 Looking in indexes: https://variants-index.wheelnext.dev/
 Collecting torch
@@ -62,7 +62,7 @@ Built as a normal Python Wheel (aka. `non variant`)
 # - variantlib (a new package)
 
 # Linux / MacOs
-$ pip install pep-xxx-wheel-variants
+$ python3 -m pip install pep-xxx-wheel-variants
 Successfully installed pep-xxx-wheel-variants-1.0.0 pip-25.1.dev0+pep.xxx.wheel.variants variantlib-0.0.1  # and some extra stuff
 
 # Windows
@@ -70,7 +70,7 @@ $ $python.exe -m pip install pep-xxx-wheel-variants
 >>> Successfully installed pep-xxx-wheel-variants-1.0.0 pip-25.1.dev0+pep.xxx.wheel.variants variantlib-0.0.1  # and some extra stuff
 
 # Let's verify everything is good:
-$ pip --version
+$ python3 -m pip --version
 pip 25.1.dev0+pep-xxx-wheel-variants from ...  # <=============== Check you can see `+pep-xxx-wheel-variants`
 
 $ variantlib --version
@@ -89,7 +89,7 @@ $ nvidia-smi | head -n 4
 
 # That means that this machine with any variant with NVIDIA CUDA >=12.0,<=12.8.
 
-$ pip install --dry-run torch
+$ python3 -m pip install --dry-run torch
 
 Looking in indexes: https://variants-index.wheelnext.dev/
   Fetching https://variants-index.wheelnext.dev/torch/torch-2.7.0-variants.json


### PR DESCRIPTION
Specifies to explicitly use the pip from your current `python3` environment. This was bugging me when I was trying out the tutorial so I'd prefer specificity over brevity here to make it less likely that someone will mess this up.