### PR TITLE
Update documentation and schema for variant labels

### DIFF
--- a/docs/design/base_definitions.md
+++ b/docs/design/base_definitions.md
@@ -24,7 +24,7 @@ do not support variants.
 ## Variant descriptions, properties, features
 
 *Variant description* is the whole set of metadata describing
-a particular variant.  It consists of one or more variant properties,
+a particular variant.  It consists of zero or more variant properties,
 and it has a corresponding *variant hash*.
 
 *Variant property* is a 3-tuple describing a single specific feature
@@ -52,6 +52,49 @@ in the example.
 *Feature value* is the selected feature value for the given variant.
 It must be unique within the feature. In the example, `CUDA :: runtime`
 feature has a value of `12.8`.
+
+
+## Null variant
+
+The *null variant* is a special variant with zero properties. For this
+variant, the special variant hash value of `00000000` is used. The null
+variant is always considered supported. All non-null variants are
+preferred over it, but it is preferred over the non-variant wheel.
+
+Null variants can only be installed by package managers supporting
+variant wheels. An example use case is a package that provides:
+
+- one or more GPU-accelerated variants that are used when
+  the appropriate GPU acceleratio is available,
+
+- a null CPU-only variant that is used when no GPU acceleration
+  is available,
+
+- a regular CPU+GPU wheel that is larger than the other wheels, and it
+  is used when variant wheels are not supported and therefore it is
+  impossible to automatically select a wheel matching the available
+  acceleration.
+
+
+## Variant label, wheel filename
+
+*Variant label* is a string that is added to the wheel filename
+to uniquely identify it as a specific variant. It defaults
+to the variant hash, but a custom string up to 8 characters can be used
+instead to provide a human-readable label for the variant.
+
+Therefore the complete wheel filename follows the following template:
+
+```
+{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}(-{variant label})?.whl
+```
+
+Variant wheel filename examples follow:
+
+- a regular wheel: `example-1.0.0-py3-none-any.whl
+- variant wheel with hash: `example-1.0.0-py3-none-any-abcd1234.whl`
+- variant wheel with custom label: `example-1.0.0-py3-none-any-accel.whl`
+
 
 
 ## Plugins

--- a/docs/design/metadata.md
+++ b/docs/design/metadata.md
@@ -56,7 +56,7 @@ structure can be visualized using the following tree:
 |         +- <feature>  : list[str]
 |
 +-- variants
-    +- <variant-hash>
+    +- <variant-label>
        +- <namespace>
           +- <feature>  : list[str]
 ```
@@ -171,7 +171,7 @@ with up to three keys:
 
 ```
 +-- variants
-    +- <variant-hash>
+    +- <variant-label>
        +- <namespace>
           +- <feature>  : str
 ```
@@ -183,7 +183,7 @@ for. In the latter, it lists all variants available for the package
 version.
 
 It resides under the `variants` key. It is a dictionary using variant
-hashes as keys, with values listing the properties for a given variant
+labels as keys, with values listing the properties for a given variant
 in a form of a nested dictionary. The keys of the top dictionary
 specify namespaces names, the keys of the subsequent dictionary feature
 names and their values are the corresponding property values.
@@ -317,8 +317,8 @@ command:
 
 ```console
 $ variantlib generate-index-json -d dist/
-variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-cp313-cp313-linux_x86_64-40aba78e.whl` with variant hash: `40aba78e`
-variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-cp313-cp313-linux_x86_64-fa7c1393.whl` with variant hash: `fa7c1393`
+variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-cp313-cp313-linux_x86_64-40aba78e.whl` with variant label: `40aba78e`
+variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-cp313-cp313-linux_x86_64-fa7c1393.whl` with variant label: `fa7c1393`
 ```
 
 The `foo-1.2.3-variants.json` corresponding to the package with two

--- a/schema/variants.schema.json
+++ b/schema/variants.schema.json
@@ -109,10 +109,10 @@
             "uniqueItems": true
         },
         "variants": {
-            "description": "Mapping of variant hashes to properties",
+            "description": "Mapping of variant labels to properties",
             "type": "object",
             "patternProperties": {
-                "^[0-9a-f]{8}$": {
+                "^[0-9a-z_]{1,8}$": {
                     "type": "object",
                     "description": "Mapping of namespaces in a variant",
                     "patternProperties": {

--- a/schema/variants.schema.json
+++ b/schema/variants.schema.json
@@ -101,7 +101,7 @@
                     "additionalProperties": false,
                     "uniqueItems": true,
                     "required": [
-                        "plugin-api"
+                        "requires"
                     ]
                 }
             },


### PR DESCRIPTION
- update the basic definitions to explain variant labels, and give examples of wheel filenames
- while at it, describe null variants (added earlier)
- update JSON schema to permit non-hash variant labels
- while at it, update JSON schema to require `requires` key for plugins rather than `plugin-api` (changed earlier)